### PR TITLE
implement support for remarkable 1.0

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 extern crate simple_server;
 
+use std::fs;
 use std::fs::File;
 use std::io::Read;
+use std::process;
 use std::thread;
 
 use byteorder::{ByteOrder, LittleEndian};
@@ -21,6 +23,18 @@ fn main() {
         Ok(response.body(Vec::from(Asset::get("index.html").unwrap()))?)
     });
 
+    let model = fs::read_to_string("/proc/device-tree/model")
+        .expect("Something went wrong reading the file");
+
+    let event_file = if model.eq("reMarkable 1.0\u{0}") {
+        "/dev/input/event0"
+    } else if model.eq("reMarkable 2.0\u{0}") {
+        "/dev/input/event1"
+    } else {
+        println!("Model is not supported: {}", model);
+        process::exit(1);
+    };
+
     thread::spawn(move || {
         println!("Listening for http connections on port 80...");
         server.listen("0.0.0.0", "80");
@@ -32,7 +46,7 @@ fn main() {
             .name(format!("connection_handler_{}", out.connection_id()))
             .spawn(move || {
                 println!("Got Connection!");
-                let mut input = File::open("/dev/input/event1").expect("opening wacom file");
+                let mut input = File::open(event_file).expect("opening wacom file");
                 let mut buf = [0u8; 16];
 
                 let mut state = DigitizerState::default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,13 +26,13 @@ fn main() {
     let model = fs::read_to_string("/proc/device-tree/model")
         .expect("Something went wrong reading the file");
 
-    let event_file = if model.eq("reMarkable 1.0\u{0}") {
-        "/dev/input/event0"
-    } else if model.eq("reMarkable 2.0\u{0}") {
-        "/dev/input/event1"
-    } else {
-        println!("Model is not supported: {}", model);
-        process::exit(1);
+    let event_file = match model.as_str() {
+        "reMarkable 1.0\u{0}" => "/dev/input/event0",
+        "reMarkable 2.0\u{0}" => "/dev/input/event1",
+        _ => {
+            println!("Model is not supported: {}", model);
+            process::exit(1);
+        }
     };
 
     thread::spawn(move || {


### PR DESCRIPTION
I've noticed from the pipes-and-paper project that the only difference
between ReMarkable 1.0 and 2.0 is the event file. I've implemented this
in the rust code here so I can use it on my remarkable.

I'm pretty sure there is a better way to handle the different hardware
versions but I'm no rust expert...